### PR TITLE
Feature/added gcm priority

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -42,7 +42,8 @@ The JSON below is the request-body example.
             "message" : "Hello, Android!",
             "collapse_key" : "update",
             "delay_while_idle" : true,
-            "time_to_live" : 10
+            "time_to_live" : 10,
+            "priority" : "normal"
         }
     ]
 }
@@ -66,8 +67,9 @@ The request-body must have the `notifications` array. Table below shows the para
 |collapse_key     |string      |the key for collapsing notifications     |-       |       |only Android                              |
 |delay_while_idle |bool        |the flag for device idling               |-       |false  |only Android                              |
 |time_to_live     |int         |expiration of message kept on FCM storage|-       |0      |only Android                              |
+|priority         |string      |deliver immediately or save battery ( high or normal)      |-       |normal   |only Android        | 
 |extend           |string array|extensible partition                     |-       |       |                                          |
-|identifier       |string      |notification identifier                  |-       |       |an optional value to identify notification|
+|identifier        |string      |notification identifier                    |-       |       |an optional value to identify notification|
 |push_type        |string      |apns-push-type                           |-       |alert  |only iOS(13.0+)                           |
 
 The JSON below is the response-body example from Gaurun. In this case, the status is 200(OK).

--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -48,6 +48,7 @@ func pushNotificationAndroid(req gaurun.RequestGaurunNotification) bool {
 	msg.CollapseKey = req.CollapseKey
 	msg.DelayWhileIdle = req.DelayWhileIdle
 	msg.TimeToLive = req.TimeToLive
+	msg.Priority = req.Priority
 
 	_, err := GCMClient.Send(msg)
 	if err != nil {

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -30,6 +30,7 @@ type RequestGaurunNotification struct {
 	CollapseKey    string `json:"collapse_key,omitempty"`
 	DelayWhileIdle bool   `json:"delay_while_idle,omitempty"`
 	TimeToLive     int    `json:"time_to_live,omitempty"`
+	Priority       string `json:"priority,omitempty"`
 	// iOS
 	Title            string       `json:"title,omitempty"`
 	Subtitle         string       `json:"subtitle,omitempty"`
@@ -140,6 +141,7 @@ func pushNotificationAndroid(req RequestGaurunNotification) error {
 	msg.CollapseKey = req.CollapseKey
 	msg.DelayWhileIdle = req.DelayWhileIdle
 	msg.TimeToLive = req.TimeToLive
+	msg.Priority = req.Priority
 
 	stime := time.Now()
 	_, err := GCMClient.Send(msg)

--- a/gcm/client.go
+++ b/gcm/client.go
@@ -15,10 +15,10 @@ const (
 )
 
 const (
-	// GcmPushPriorityHigh and GcmPushPriorityNormal is priority of a delivery message options
+	// fcmPushPriorityHigh and fcmPushPriorityNormal is priority of a delivery message options
 	// See more on https://firebase.google.com/docs/cloud-messaging/concept-options?hl=en#setting-the-priority-of-a-message
-	GcmPushPriorityHigh   = "high"
-	GcmPushPriorityNormal = "normal"
+	fcmPushPriorityHigh   = "high"
+	fcmPushPriorityNormal = "normal"
 )
 
 const (

--- a/gcm/client.go
+++ b/gcm/client.go
@@ -15,6 +15,13 @@ const (
 )
 
 const (
+	// GcmPushPriorityHigh and GcmPushPriorityNormal is priority of a delivery message options
+	// See more on https://firebase.google.com/docs/cloud-messaging/concept-options?hl=en#setting-the-priority-of-a-message
+	GcmPushPriorityHigh   = "high"
+	GcmPushPriorityNormal = "normal"
+)
+
+const (
 	// maxRegistrationIDs are max number of registration IDs in one message.
 	maxRegistrationIDs = 1000
 

--- a/gcm/message.go
+++ b/gcm/message.go
@@ -14,6 +14,7 @@ type Message struct {
 	Data                  map[string]interface{} `json:"data,omitempty"`
 	DelayWhileIdle        bool                   `json:"delay_while_idle,omitempty"`
 	TimeToLive            int                    `json:"time_to_live,omitempty"`
+	Priority              string                 `json:"priority,omitempty"`
 	RestrictedPackageName string                 `json:"restricted_package_name,omitempty"`
 	DryRun                bool                   `json:"dry_run,omitempty"`
 }
@@ -48,6 +49,10 @@ func (m *Message) validate() error {
 			"the message's TimeToLive field must be an integer between 0 and %d (4 weeks)",
 			maxTimeToLive,
 		)
+	}
+
+	if m.Priority != "" && m.Priority != GcmPushPriorityHigh && m.Priority != GcmPushPriorityNormal {
+		return fmt.Errorf("push_type must be %s or %s", GcmPushPriorityHigh, GcmPushPriorityNormal)
 	}
 
 	return nil

--- a/gcm/message.go
+++ b/gcm/message.go
@@ -51,8 +51,8 @@ func (m *Message) validate() error {
 		)
 	}
 
-	if m.Priority != "" && m.Priority != GcmPushPriorityHigh && m.Priority != GcmPushPriorityNormal {
-		return fmt.Errorf("push_type must be %s or %s", GcmPushPriorityHigh, GcmPushPriorityNormal)
+	if m.Priority != "" && m.Priority != fcmPushPriorityHigh && m.Priority != fcmPushPriorityNormal {
+		return fmt.Errorf("priority must be %s or %s", fcmPushPriorityHigh, fcmPushPriorityNormal)
 	}
 
 	return nil

--- a/gcm/message_test.go
+++ b/gcm/message_test.go
@@ -58,6 +58,41 @@ func TestValidateMessage(t *testing.T) {
 			},
 			false,
 		},
+		// test should pass when Priority is empty
+		{
+			&Message{
+				RegistrationIDs: []string{"1"},
+				Priority:        "",
+			},
+			true,
+		},
+
+		// test should pass when Priority is high
+		{
+			&Message{
+				RegistrationIDs: []string{"1"},
+				Priority:        "high",
+			},
+			true,
+		},
+
+		// test should pass when Priority is normal
+		{
+			&Message{
+				RegistrationIDs: []string{"1"},
+				Priority:        "normal",
+			},
+			true,
+		},
+
+		// test should fail when message Priority is not high nor normal
+		{
+			&Message{
+				RegistrationIDs: []string{"1"},
+				Priority:        "invalid_priority",
+			},
+			false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
## Description
- Added priority parameter
### Usecase
- When I want to be sure to notify push even in deep sleep mode on Android.

### FYI
- https://firebase.google.com/docs/cloud-messaging/concept-options?hl=en#setting-the-priority-of-a-message